### PR TITLE
chore: add maintenance section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ After that you will have copies of certificates in your `/srv/certs/mydomain.com
 
 ## Maintenance
 
-See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ You can add `-it` for interactive shell.
 
 After that you will have copies of certificates in your `/srv/certs/mydomain.com/` folder.
 
+## Maintenance
+
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.


### PR DESCRIPTION
## What changed
- Added a `## Maintenance` section to README.
- Added the contribution reference line: `See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.`

## Why
- Makes maintenance expectations explicit and consistent across Dockette repositories.