### PR TITLE
Add Docker CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ name: "Docker"
 on:
   workflow_dispatch:
 
+  pull_request:
+
   push:
     branches: ["master"]
 
@@ -37,6 +39,7 @@ jobs:
   build:
     name: "Build"
     needs: ["test"]
+    if: github.ref == 'refs/heads/master'
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: "Docker"
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: ["master"]
+
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build image"
+        uses: docker/build-push-action@v6
+        with:
+          context: "."
+          load: true
+          tags: "dockette/letsencrypt:latest"
+
+      - name: "Test image"
+        run: "make test"
+
+  build:
+    name: "Build"
+    needs: ["test"]
+    uses: dockette/.github/.github/workflows/docker.yml@master
+    secrets: inherit
+    with:
+      image: "dockette/letsencrypt"
+      tag: "latest"
+      context: "."
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/letsencrypt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Project
+
+Dockette LetsEncrypt builds `dockette/letsencrypt`, a legacy Debian Jessie image that runs nginx and the Let's Encrypt client to create certificates for configured domains.
+
+## Images
+
+- Default image: `dockette/letsencrypt:latest`.
+- Build context: repository root `.` with `Dockerfile`, `generate.sh`, and `nginx.conf`.
+- Runtime certificate output: `/var/www/certs`.
+- ACME challenge webroot: `/var/www/acme-certs` served by nginx on port `80`.
+- Exposed ports: `80` and `443`.
+- This image is legacy because it depends on Debian Jessie and the historical `letsencrypt-auto` flow. Keep changes conservative unless the base image and client are intentionally modernized.
+
+## Commands
+
+- `make build` builds `${DOCKER_IMAGE}:${DOCKER_TAG}` from `.`.
+- `make test` runs shell syntax, filesystem, and nginx configuration smoke checks against the built image.
+- `make run` opens an interactive shell in the image so local inspection does not start a real ACME certificate request.
+
+## Testing Notes
+
+- Do not make real ACME or Let's Encrypt calls in tests or CI.
+- Prefer `make test` after Dockerfile, `generate.sh`, or `nginx.conf` changes.
+- Use `make -n build test run` to dry-run command wiring without requiring Docker.
+- The smoke test requires Docker and a previously built `${DOCKER_IMAGE}:${DOCKER_TAG}` image.
+
+## Guidelines
+
+- Keep `Dockerfile`, `Makefile`, README, `generate.sh`, `nginx.conf`, and `.github/workflows/docker.yml` aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce real certificate issuance into automated checks.
+- Do not introduce unrelated formatting or structural changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+DOCKER_IMAGE=dockette/letsencrypt
+DOCKER_TAG?=latest
+DOCKER_PLATFORMS?=linux/amd64,linux/arm64
+
+.PHONY: build
+build:
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+
+.PHONY: test
+test:
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} bash -n /generate.sh
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} sh -lc 'test -x /generate.sh && test -d /var/www/acme-certs && test -d /var/www/certs'
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} sh -lc 'sed -i '\''s/$$DOMAINS/example.test/g'\'' /etc/nginx/nginx.conf && nginx -t'
+
+.PHONY: run
+run:
+	docker run --rm -it --entrypoint /bin/bash ${DOCKER_IMAGE}:${DOCKER_TAG}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ server {
 
 ```sh
 docker run \
-    -p 80:80 \ 
+    -p 80:80 \
     -v /srv/certs/mydomain.com:/var/www/certs \
     --name le \
     -e DOMAINS='mydomain.com www.mydomain.com' \
@@ -42,7 +42,7 @@ docker run \
     dockette/letsencrypt:latest
 ```
 
-You can add `-it` for interactive shell.
+For local inspection, use `make run` or override the entrypoint with `--entrypoint /bin/bash` so the container opens a shell instead of running `generate.sh` and requesting a real certificate.
 
 After that you will have copies of certificates in your `/srv/certs/mydomain.com/` folder.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# LetsEncrypt
+<h1 align=center>Dockette / LetsEncrypt</h1>
 
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/letsencrypt.svg?style=flat)](https://hub.docker.com/r/dockette/letsencrypt/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/letsencrypt.svg?style=flat)](https://hub.docker.com/r/dockette/letsencrypt/)
+<p align=center>
+   <a href="https://github.com/dockette/letsencrypt/actions"><img src="https://github.com/dockette/letsencrypt/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/letsencrypt"><img src="https://img.shields.io/docker/pulls/dockette/letsencrypt.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
 
 Create 90 days SSL certificates for given domains.
 


### PR DESCRIPTION
What changed
- Added the standard Dockette Docker workflow with Test, Build, and Docs jobs.
- Added Makefile build, test, and run targets with dry-run shell/config smoke checks only.
- Normalized README badges to the dockette/copybara style and added repo-local AGENTS/CLAUDE instructions.

Why
- Establishes the Dockette CI rollout baseline for dockette/letsencrypt without making real ACME or Let's Encrypt calls in CI.